### PR TITLE
aws.iam does not find locate_credentials()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,4 @@ Suggests:
     aws.ec2metadata (>= 0.1.5)
 URL: https://github.com/cloudyr/aws.signature
 BugReports: https://github.com/cloudyr/aws.signature/issues
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/R/locate_credentials.R
+++ b/R/locate_credentials.R
@@ -1,4 +1,4 @@
-#' @rdname credentials
+#' @rdname locate_credentials
 #' @title Locate AWS Credentials
 #' @description Locate AWS credentials from likely sources
 #' @param key An AWS Access Key ID

--- a/aws.signature.Rproj
+++ b/aws.signature.Rproj
@@ -1,0 +1,18 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/man/locate_credentials.Rd
+++ b/man/locate_credentials.Rd
@@ -6,8 +6,9 @@
 \usage{
 locate_credentials(key = NULL, secret = NULL, session_token = NULL,
   region = NULL, file = Sys.getenv("AWS_SHARED_CREDENTIALS_FILE",
-  default_credentials_file()), profile = Sys.getenv("AWS_PROFILE", "default"),
-  default_region = "us-east-1", verbose = getOption("verbose", FALSE))
+  default_credentials_file()), profile = Sys.getenv("AWS_PROFILE",
+  "default"), default_region = "us-east-1",
+  verbose = getOption("verbose", FALSE))
 }
 \arguments{
 \item{key}{An AWS Access Key ID}

--- a/man/signature_v2_auth.Rd
+++ b/man/signature_v2_auth.Rd
@@ -4,10 +4,10 @@
 \alias{signature_v2_auth}
 \title{Signature Version 2}
 \usage{
-signature_v2_auth(datetime = format(Sys.time(), "\%Y-\%m-\%dT\%H:\%M:\%S", tz
-  = "UTC"), verb, service, path, query_args = list(), key = NULL,
-  secret = NULL, region = NULL, force_credentials = FALSE,
-  verbose = getOption("verbose", FALSE))
+signature_v2_auth(datetime = format(Sys.time(),
+  "\%Y-\%m-\%dT\%H:\%M:\%S", tz = "UTC"), verb, service, path,
+  query_args = list(), key = NULL, secret = NULL, region = NULL,
+  force_credentials = FALSE, verbose = getOption("verbose", FALSE))
 }
 \arguments{
 \item{datetime}{A character string containing a date in the form of \dQuote{YYYY-MM-DDTH:M:S}. If missing, it is generated automatically using \code{\link[base]{Sys.time}}.}

--- a/man/signature_v4.Rd
+++ b/man/signature_v4.Rd
@@ -5,8 +5,8 @@
 \title{Signature Version 4}
 \usage{
 signature_v4(secret = NULL, date = format(Sys.time(), "\%Y\%m\%d"),
-  region = NULL, service, string_to_sign, verbose = getOption("verbose",
-  FALSE))
+  region = NULL, service, string_to_sign,
+  verbose = getOption("verbose", FALSE))
 }
 \arguments{
 \item{secret}{An AWS Secret Access Key. If \code{NULL}, it is retrieved using \code{\link{locate_credentials}}.}

--- a/man/signature_v4_auth.Rd
+++ b/man/signature_v4_auth.Rd
@@ -4,11 +4,12 @@
 \alias{signature_v4_auth}
 \title{Signature Version 4}
 \usage{
-signature_v4_auth(datetime = format(Sys.time(), "\%Y\%m\%dT\%H\%M\%SZ", tz =
-  "UTC"), region = NULL, service, verb, action, query_args = list(),
-  canonical_headers, request_body, key = NULL, secret = NULL,
-  session_token = NULL, query = FALSE, algorithm = "AWS4-HMAC-SHA256",
-  force_credentials = FALSE, verbose = getOption("verbose", FALSE))
+signature_v4_auth(datetime = format(Sys.time(), "\%Y\%m\%dT\%H\%M\%SZ",
+  tz = "UTC"), region = NULL, service, verb, action,
+  query_args = list(), canonical_headers, request_body, key = NULL,
+  secret = NULL, session_token = NULL, query = FALSE,
+  algorithm = "AWS4-HMAC-SHA256", force_credentials = FALSE,
+  verbose = getOption("verbose", FALSE))
 }
 \arguments{
 \item{datetime}{A character string containing a datetime in the form of \dQuote{YYYYMMDDTHHMMSSZ}. If missing, it is generated automatically using \code{\link[base]{Sys.time}}.}


### PR DESCRIPTION
Hi @leeper ,

when I was building the package aws.iam it shows this warning:
```
link 'locate_credentials' in package 'aws.signature' does not exist and so has been treated as a topic
``` 
This warning results that aws.iam does not recognize locate_credentials() from importFrom.
In the aws.signature, the rname for locate_credentials() was 'credentials'. Change for locate_credentials fixed the problem.

Here is a code you can run:
```
library(aws.iam)

# create user
u <- create_user("example-user")
```

