### PR TITLE
Fix cred bug

### DIFF
--- a/R/locate_credentials.R
+++ b/R/locate_credentials.R
@@ -250,7 +250,7 @@ function(
     }
     if (file.exists(file.path(".aws", "credentials"))) {
         ## in working directory
-        cred <- read_credentials(file.path(".aws", "credentials"))[[profile]]
+        cred <- read_credentials(file.path(".aws", "credentials"))
         if (profile %in% names(cred)) {
             cred <- cred[[profile]]
         } else {

--- a/R/locate_credentials.R
+++ b/R/locate_credentials.R
@@ -268,10 +268,10 @@ function(
     } else if (file.exists(file) || file.exists(default_credentials_file())) {
         ## in specified location
         if (file.exists(file)) {
-            cred <- read_credentials(file = file)[[profile]]
+            cred <- read_credentials(file = file)
         } else {
             ## otherwise, default to default location
-            cred <- read_credentials(file = default_credentials_file())[[profile]]
+            cred <- read_credentials(file = default_credentials_file())
         }
         if (profile %in% names(cred)) {
             cred <- cred[[profile]]

--- a/R/locate_credentials.R
+++ b/R/locate_credentials.R
@@ -368,6 +368,8 @@ function(
         if (isTRUE(verbose)) {
             message("Using value in credentials file for AWS Session Token")
         }
+    } else {
+        session_token <- NULL
     }
     # now find region, with fail safes (including credentials file)
     if (!is.null(region) && region != "") {


### PR DESCRIPTION
Bug fix for issue [#39](https://github.com/cloudyr/aws.signature/issues/39) that I was also running into.
Duplicated issue with additional comments for context [here](https://github.com/cloudyr/aws.secrets/issues/2).

In the function `locate_credentials`, creds are read in as a named list (where the profile are the keys) and then subset _twice_, resulting in a `NULL` being passed in for the `cred` argument to `credentials_to_list`. `credentials_to_list` then raises an error because `key` is never defined.

The other issue was that `credentials_to_list` expects the session token to always be included in credentials even though it's optional. So I added an `else` statement that defines `session_token` as `NULL` if the credentials file doesn't contain a session token.

