### PR TITLE
Improve region handling

### DIFF
--- a/R/locate_credentials.R
+++ b/R/locate_credentials.R
@@ -31,7 +31,7 @@
 #'   \item the \env{AWS_DEFAULT_REGION} environment variable
 #'   \item (only on EC2 instances) a region declared in the instance metadata
 #'   \item (if a credentials file is being used) the value specified therein
-#'   \item the default value specified in \code{default_region} (i.e., \dQuote{us-east-1})
+#'   \item the default value specified in \code{default_region} (i.e., \dQuote{us-east-1} - this can be overriden with the option \dQuote{cloudyr.aws.default_region})
 #' }
 #' 
 #' As such, user-supplied values of \code{region} always trump any other value.
@@ -46,7 +46,7 @@ function(
   region = NULL,
   file = Sys.getenv("AWS_SHARED_CREDENTIALS_FILE", default_credentials_file()),
   profile = Sys.getenv("AWS_PROFILE", "default"),
-  default_region = "us-east-1",
+  default_region = getOption("cloudyr.aws.default_region", "us-east-1"),
   verbose = getOption("verbose", FALSE)
 ) {
     
@@ -279,7 +279,7 @@ credentials_to_list <-
 function(
   cred,
   region = NULL,
-  default_region = "us-east-1",
+  default_region = getOption("cloudyr.aws.default_region", "us-east-1"),
   verbose = getOption("verbose", FALSE)
 ) {
     key <- NULL
@@ -307,7 +307,7 @@ function(
         session_token <- NULL
     }
     # now find region, with fail safes (including credentials file)
-    if (!is.null(region) && region != "") {
+    if (!is_blank(region)||((region=="")&&getOption("cloudyr.aws.allow_empty_region", FALSE))) {
         region <- region
         if (isTRUE(verbose)) {
             message(sprintf("Using user-supplied value for AWS Region ('%s')", region))
@@ -338,12 +338,12 @@ function(
 find_region_with_failsafe <-
 function(
   region = NULL,
-  default_region = "us-east-1",
+  default_region = getOption("cloudyr.aws.default_region", "us-east-1"),
   verbose = getOption("verbose", FALSE),
   try_ec2 = FALSE
 ) {
   # if we have a valid argument, just return it
-  if (!is_blank(region)) {
+  if (!is_blank(region)||((region=="")&&getOption("cloudyr.aws.allow_empty_region", FALSE))) {
     if (isTRUE(verbose)) {
       message(sprintf("Using user-supplied value for AWS Region ('%s')", region))
     }

--- a/man/locate_credentials.Rd
+++ b/man/locate_credentials.Rd
@@ -7,8 +7,8 @@
 locate_credentials(key = NULL, secret = NULL, session_token = NULL,
   region = NULL, file = Sys.getenv("AWS_SHARED_CREDENTIALS_FILE",
   default_credentials_file()), profile = Sys.getenv("AWS_PROFILE",
-  "default"), default_region = "us-east-1",
-  verbose = getOption("verbose", FALSE))
+  "default"), default_region = getOption("cloudyr.aws.default_region",
+  "us-east-1"), verbose = getOption("verbose", FALSE))
 }
 \arguments{
 \item{key}{An AWS Access Key ID}
@@ -53,7 +53,7 @@ Because region is often handled slightly differently from credentials and is req
   \item the \env{AWS_DEFAULT_REGION} environment variable
   \item (only on EC2 instances) a region declared in the instance metadata
   \item (if a credentials file is being used) the value specified therein
-  \item the default value specified in \code{default_region} (i.e., \dQuote{us-east-1})
+  \item the default value specified in \code{default_region} (i.e., \dQuote{us-east-1} - this can be overriden with the option \dQuote{cloudyr.aws.default_region})
 }
 
 As such, user-supplied values of \code{region} always trump any other value.

--- a/tests/testthat/tests-locate_credentials.R
+++ b/tests/testthat/tests-locate_credentials.R
@@ -135,5 +135,59 @@ if (file.exists(".aws/credentials")) {
         # restore environment variables
         do.call("Sys.setenv", as.list(e))
     })
-    
+
+    test_that("locate_credentials() uses options default for region", {
+
+        skip_on_cran()
+
+        # save environment variables
+        e <- Sys.getenv(c("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_DEFAULT_REGION"))
+
+        # unset environment variables
+        Sys.unsetenv("AWS_ACCESS_KEY_ID")
+        Sys.unsetenv("AWS_SECRET_ACCESS_KEY")
+        Sys.unsetenv("AWS_SESSION_TOKEN")
+        Sys.unsetenv("AWS_DEFAULT_REGION")
+        cloudyr_region <- getOption("cloudyr.aws.default_region")
+        options(cloudyr.aws.default_region = "eu-west-1")
+
+        # tests
+        cred <- locate_credentials()
+        expect_equal(cred[["key"]], "ACCESS_KEY")
+        expect_equal(cred[["secret"]], "SECRET_KEY")
+        expect_equal(cred[["session_token"]], "TOKEN")
+        expect_equal(cred[["region"]], "eu-west-1")
+
+        # restore environment variables
+        do.call("Sys.setenv", as.list(e))
+        options(cloudyr.aws.default_region = cloudyr_region)
+    })
+
+    test_that("locate_credentials() allows empty region with allow_empty_set", {
+
+        skip_on_cran()
+
+        # save environment variables
+        e <- Sys.getenv(c("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_DEFAULT_REGION"))
+
+        # unset environment variables
+        Sys.unsetenv("AWS_ACCESS_KEY_ID")
+        Sys.unsetenv("AWS_SECRET_ACCESS_KEY")
+        Sys.unsetenv("AWS_SESSION_TOKEN")
+        Sys.unsetenv("AWS_DEFAULT_REGION")
+        cloudyr_region <- getOption("cloudyr.aws.allow_empty_region")
+        options(cloudyr.aws.allow_empty_region = TRUE)
+
+        # tests
+        cred <- locate_credentials(region="")
+        expect_equal(cred[["key"]], "ACCESS_KEY")
+        expect_equal(cred[["secret"]], "SECRET_KEY")
+        expect_equal(cred[["session_token"]], "TOKEN")
+        expect_equal(cred[["region"]], "")
+
+        # restore environment variables
+        do.call("Sys.setenv", as.list(e))
+        options(cloudyr.aws.allow_empty_region = cloudyr_region)
+    })
+
 }


### PR DESCRIPTION
Fixes #44

This adds options for region handling.

* `cloudyr.aws.default_region` overrides the default region
* `cloudyr.aws.allow_empty_region` lets locate_credentials() returns an empty (i.e. "" region)

This seems a bit safer than changing some long existing functionality for all users of the package.


